### PR TITLE
fix bug in npm install with packageDir

### DIFF
--- a/tasks/lib/check-dependencies.js
+++ b/tasks/lib/check-dependencies.js
@@ -63,7 +63,7 @@ module.exports = function (grunt) {
                 grunt.log.writeln('Invoking ' + 'npm install'.green + '...');
                 // execSync errors on non-empty stderr; silent such output.
                 spawn('npm', ['install'], {
-                    cwd: '.',
+                    cwd: packageDir || '.',
                     stdio: 'inherit',
                 }).on('close', function (code) {
                         if (code !== 0) {


### PR DESCRIPTION
Hi Michael,

if you have the option "packageDir: common/dir" with the option "npmInstall: true" the package.json in the directory "common/dir" should be read by npm  and not the package.json of root directory.

Kind Regards

Wilhelm
