### PR TITLE
Allow to continue after checking using an option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,6 +53,13 @@ module.exports = function (grunt) {
                     install: true,
                 },
             },
+            notOkCopyInstallContinue: {
+                options: {
+                    packageDir: './test/not-ok-install-copy/',
+                    install: true,
+                    continue: true,
+                },
+            },
             notOkCopy: {
                 options: {
                     packageDir: './test/not-ok-install-copy/',

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Below is a description of a few most basic options
     // If true, on error, instead of failing the task, `npm install` will be invoked for the user.
     // Default: `false`.
     install: boolean,
+
+    // If true, instead of aborting the task after checking (and installing), the task will continue.
+    // Default: `false`.
+    continue: boolean,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ If you want to automatically install missing packages, here's what you want:
 }
 ```
 
+If you want to automatically install missing packages without interrupting the task, you can use:
+```js
+{
+    checkDependencies: {
+        this: {
+            options: {
+                install: true,
+                continue: true,
+            },
+        },
+    },
+}
+```
+However, be careful with the `continue` option as the tasks loaded before will not be updated unless re-running the task. This will also be the case with plugins like `load-grunt-tasks`.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/check-dependencies.js
+++ b/tasks/check-dependencies.js
@@ -17,7 +17,8 @@ module.exports = function (grunt) {
             'that are specified in package.json',
         function () {
             var options = cloneDeep(this.options()),
-                done = this.async();
+                done = this.async(),
+                needContinue = options.continue === true;
 
             options.log = grunt.verbose.writeln;
             options.error = grunt.log.error;
@@ -33,9 +34,11 @@ module.exports = function (grunt) {
                 // obsolete Grunt tasks loaded so it's better to fail this time and require
                 // a re-run.
                 if (output.status === 0 && !output.depsWereOk) {
-                    grunt.log.error('Dependencies have been updated. Please re-run your Grunt task.');
+                    if (!needContinue) {
+                        grunt.log.error('Dependencies have been updated. Please re-run your Grunt task.');
+                    }
                 }
-                done(output.status === 0 && output.depsWereOk);
+                done(output.status === 0 && (output.depsWereOk || needContinue));
             });
         }
     );

--- a/test/spec.js
+++ b/test/spec.js
@@ -53,4 +53,27 @@ describe('Task: checkDependencies', function () {
                 });
         });
     });
+
+    it('should install missing packages and continue when `install` and `continue` are set to true', function (done) {
+        this.timeout(30000);
+
+        var versionRange = require('./not-ok-install/package.json').dependencies.minimatch,
+            version = JSON.parse(fs.readFileSync(__dirname +
+                '/not-ok-install/node_modules/minimatch/package.json')).version;
+
+        assert.equal(semver.satisfies(version, versionRange),
+            false, 'Expected version ' + version + ' not to match ' + versionRange);
+
+        fs.remove(__dirname + '/not-ok-install-copy', function (error) {
+            assert.equal(error, null);
+            fs.copy(__dirname + '/not-ok-install', __dirname + '/not-ok-install-copy',
+                function (error) {
+                    assert.equal(error, null);
+                    exec('grunt checkDependencies:notOkCopyInstallContinue', function (error) {
+                        assert.equal(error, null);
+                        done();
+                    });
+                });
+        });
+    });
 });


### PR DESCRIPTION
With the following config, the task checks missing dependencies, eventually install them and continue running the end of the grunt task.
        options:
          packageManager: 'npm'
          install: true
          continue: true